### PR TITLE
Fails CRAN check: see details in comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,17 +21,17 @@ License: GPL-2
 URL: https://github.com/great-northern-diver/diver/
 BugReports: https://github.com/great-northern-diver/diver/issues
 Depends: 
-    R (>= 3.4)
+    R (>= 3.4),
+    loon (>= 1.2.2)
 Imports: 
     cli (>= 1.1.0),
     crayon (>= 1.3.4),
     rstudioapi (>= 0.10),
-    loon (>= 1.2.2),
     loon.data,
     ggmulti,
-    loon.ggplot (>= 1.1.0),
+    loon.ggplot,
     zenplots,
     loon.shiny,
     loon.tourr
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,17 +21,18 @@ License: GPL-2
 URL: https://github.com/great-northern-diver/diver/
 BugReports: https://github.com/great-northern-diver/diver/issues
 Depends: 
-    R (>= 3.4),
-    loon (>= 1.2.2)
+    R (>= 3.4)
 Imports: 
     cli (>= 1.1.0),
     crayon (>= 1.3.4),
     rstudioapi (>= 0.10),
+    loon (>= 1.2.2),
     loon.data,
     ggmulti,
     loon.ggplot,
     zenplots,
     loon.shiny,
-    loon.tourr
+    loon.tourr,
+    stats
 Encoding: UTF-8
 RoxygenNote: 7.1.2

--- a/R/attach.R
+++ b/R/attach.R
@@ -19,10 +19,15 @@ core_unloaded <- function() {
 # Attach the package from the same package library it was
 # loaded from before.
 same_library <- function(pkg) {
-  loc <- if (pkg %in% loadedNamespaces()) dirname(getNamespaceInfo(pkg, "path"))
+  loc <- if (pkg %in% loadedNamespaces()) {
+    dirname(getNamespaceInfo(pkg, "path"))
+    }
   do.call(
     "library",
-    list(pkg, lib.loc = loc, character.only = TRUE, warn.conflicts = FALSE)
+    list(pkg,
+         lib.loc = loc,
+         character.only = TRUE,
+         warn.conflicts = FALSE)
   )
 }
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -134,7 +134,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -134,7 +134,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -134,7 +134,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.11.4
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles: {}
-last_built: 2021-05-14T20:46Z
+last_built: 2021-09-28T17:44Z
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.11.4
 pkgdown: 1.6.1
 pkgdown_sha: ~
 articles: {}
-last_built: 2021-09-28T17:44Z
+last_built: 2021-09-28T18:59Z
 

--- a/docs/reference/diveR_packages.html
+++ b/docs/reference/diveR_packages.html
@@ -135,7 +135,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>

--- a/docs/reference/diveR_packages.html
+++ b/docs/reference/diveR_packages.html
@@ -176,7 +176,7 @@
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='fu'>diveR_packages</span><span class='op'>(</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; [1] "loon"        "loon.data"   "ggmulti"     "loon.ggplot" "zenplots"   
-#&gt; [6] "loon.shiny"  "loon.tourr"  "diveR"      </div></pre>
+#&gt; [6] "loon.shiny"  "loon.tourr"  "stats"       "diveR"      </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -134,7 +134,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/great-northern-diver/diveR">
-    <span class="fas fa-github fa-lg"></span>
+    <span class="fa fa-github fa-lg"></span>
      
   </a>
 </li>


### PR DESCRIPTION
_____________
==> devtools::check(args = c('--as-cran'))

ℹ Updating diveR documentation
ℹ Loading diveR
Loading required package: loon
Loading required package: tcltk
loon Version 1.3.8.
To learn more about loon, see l_web().
Registered S3 method overwritten by 'loon.tourr':
  method                from
  l_getPlots.l_compound loon
── Attaching packages ─────────────────────────────────── diveR 0.1.2 ──
✓ loon.data   0.1.3     ✓ zenplots    1.0.5
✓ ggmulti     1.0.4     ✓ loon.shiny  1.0.1
✓ loon.ggplot 1.3.0     ✓ loon.tourr  0.1.2
To learn more about any diveR package, see l_web().
E.g.	l_web(package = "loon")
	l_web(package = "loon.data")
	l_web(package = "ggmulti")
	l_web(package = "loon.ggplot")
	l_web(package = "zenplots")
	l_web(package = "loon.shiny")
	l_web(package = "loon.tourr")

Writing NAMESPACE
Writing NAMESPACE
── Building ─────────────────────────────────────────────────── diveR ──
Setting env vars:
• CFLAGS    : -Wall -pedantic -fdiagnostics-color=always
• CXXFLAGS  : -Wall -pedantic -fdiagnostics-color=always
• CXX11FLAGS: -Wall -pedantic -fdiagnostics-color=always
────────────────────────────────────────────────────────────────────────
✓  checking for file ‘/Users/rwoldford/Documents/Software/Loon/diveR/DESCRIPTION’ ...
─  preparing ‘diveR’:
✓  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘diveR_0.1.2.tar.gz’

── Checking ─────────────────────────────────────────────────── diveR ──
Setting env vars:
• _R_CHECK_CRAN_INCOMING_REMOTE_: FALSE
• _R_CHECK_CRAN_INCOMING_       : FALSE
• _R_CHECK_FORCE_SUGGESTS_      : FALSE
• NOT_CRAN                      : true
── R CMD check ─────────────────────────────────────────────────────────────────
─  using log directory ‘/Users/rwoldford/Documents/Software/Loon/diveR.Rcheck’
─  using R version 4.1.0 (2021-05-18)
─  using platform: x86_64-apple-darwin17.0 (64-bit)
─  using session charset: UTF-8
─  using options ‘--no-manual --as-cran’
✓  checking for file ‘diveR/DESCRIPTION’
─  checking extension type ... Package
─  this is package ‘diveR’ version ‘0.1.2’
─  package encoding: UTF-8
✓  checking package namespace information ...
✓  checking package dependencies (3.4s)
✓  checking if this is a source package
✓  checking if there is a namespace
✓  checking for executable files ...
✓  checking for hidden files and directories
✓  checking for portable file names
✓  checking for sufficient/correct file permissions
✓  checking serialization versions
✓  checking whether package ‘diveR’ can be installed (4.1s)
✓  checking installed package size ...
✓  checking package directory ...
✓  checking for future file timestamps (6.5s)
✓  checking DESCRIPTION meta-information ...
✓  checking top-level files
✓  checking for left-over files
✓  checking index information
✓  checking package subdirectories ...
✓  checking R files for non-ASCII characters ...
✓  checking R files for syntax errors ...
✓  checking whether the package can be loaded (1.5s)
─  checking whether the package can be loaded with stated dependencies ...Loading required package: loon (926ms)
   Loading required package: methods
   Loading required package: tcltk
   loon Version 1.3.8.
   To learn more about loon, see l_web().
   ── Attaching packages ─────────────────────────────────────────── diveR 0.1.2 ──
   ✓ loon.data   0.1.3     ✓ zenplots    1.0.5
   ✓ ggmulti     1.0.4     ✓ loon.shiny  1.0.1
   ✓ loon.ggplot 1.3.0     ✓ loon.tourr  0.1.2
   To learn more about any diveR package, see l_web().
   E.g.	l_web(package = "loon")
   	l_web(package = "loon.data")
   	l_web(package = "ggmulti")
   	l_web(package = "loon.ggplot")
   	l_web(package = "zenplots")
   	l_web(package = "loon.shiny")
   	l_web(package = "loon.tourr")

   Error: package or namespace load failed for ‘diveR’:
    .onAttach failed in attachNamespace() for 'diveR', details:
     call: NULL
     error: package or namespace load failed for ‘loon.ggplot’:
    .onAttach failed in attachNamespace() for 'loon.ggplot', details:
     call: runif(1)
     error: could not find function "runif"
   Execution halted

   It looks like this package (or one of its dependent packages) has an
   unstated dependence on a standard package.  All dependencies must be
   declared in DESCRIPTION.
   See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
   manual.
W  checking whether the package can be unloaded cleanly (911ms)
   Error: package or namespace load failed for ‘diveR’:
    .onAttach failed in attachNamespace() for 'diveR', details:
     call: NULL
     error: package or namespace load failed for ‘loon.ggplot’:
    .onAttach failed in attachNamespace() for 'loon.ggplot', details:
     call: runif(1)
     error: could not find function "runif"
   Execution halted
✓  checking whether the namespace can be loaded with stated dependencies ...
✓  checking whether the namespace can be unloaded cleanly ...
N  checking dependencies in R code (914ms)
   Error: package or namespace load failed for ‘diveR’:
    .onAttach failed in attachNamespace() for 'diveR', details:
     call: NULL
     error: package or namespace load failed for ‘loon.ggplot’:
    .onAttach failed in attachNamespace() for 'loon.ggplot', details:
     call: runif(1)
     error: could not find function "runif"
   Call sequence:
   6: stop(msg, call. = FALSE, domain = NA)
   5: value[[3L]](cond)
   4: tryCatchOne(expr, names, parentenv, handlers[[1L]])
   3: tryCatchList(expr, classes, parentenv, handlers)
   2: tryCatch({
          attr(package, "LibPath") <- which.lib.loc
          ns <- loadNamespace(package, lib.loc)
          env <- attachNamespace(ns, pos = pos, deps, exclude, include.only)
      }, error = function(e) {
          P <- if (!is.null(cc <- conditionCall(e)))
              paste(" in", deparse(cc)[1L])
          else ""
          msg <- gettextf("package or namespace load failed for %s%s:\n %s",
              sQuote(package), P, conditionMessage(e))
          if (logical.return)
              message(past
   Execution halted
✓  checking S3 generic/method consistency (2.4s)
✓  checking replacement functions (1.5s)
✓  checking foreign function calls (1.5s)
✓  checking R code for possible problems (5.8s)
✓  checking Rd files ...
✓  checking Rd metadata ...
✓  checking Rd line widths ...
✓  checking Rd cross-references ...
✓  checking for missing documentation entries (1.5s)
✓  checking for code/documentation mismatches (4.4s)
✓  checking Rd \usage sections (2.6s)
✓  checking Rd contents ...
✓  checking for unstated dependencies in examples ...
✓  checking examples (1.8s)
✓  checking for non-standard things in the check directory
✓  checking for detritus in the temp directory

   See
     ‘/Users/rwoldford/Documents/Software/Loon/diveR.Rcheck/00check.log’
   for details.

── R CMD check results ──────────────────────────────────────── diveR 0.1.2 ────
Duration: 41.3s

> checking whether the package can be unloaded cleanly ... WARNING
  Error: package or namespace load failed for ‘diveR’:
   .onAttach failed in attachNamespace() for 'diveR', details:
    call: NULL
    error: package or namespace load failed for ‘loon.ggplot’:
   .onAttach failed in attachNamespace() for 'loon.ggplot', details:
    call: runif(1)
    error: could not find function "runif"
  Execution halted

> checking dependencies in R code ... NOTE
  Error: package or namespace load failed for ‘diveR’:
   .onAttach failed in attachNamespace() for 'diveR', details:
    call: NULL
    error: package or namespace load failed for ‘loon.ggplot’:
   .onAttach failed in attachNamespace() for 'loon.ggplot', details:
    call: runif(1)
    error: could not find function "runif"
  Call sequence:
  6: stop(msg, call. = FALSE, domain = NA)
  5: value[[3L]](cond)
  4: tryCatchOne(expr, names, parentenv, handlers[[1L]])
  3: tryCatchList(expr, classes, parentenv, handlers)
  2: tryCatch({
         attr(package, "LibPath") <- which.lib.loc
         ns <- loadNamespace(package, lib.loc)
         env <- attachNamespace(ns, pos = pos, deps, exclude, include.only)
     }, error = function(e) {
         P <- if (!is.null(cc <- conditionCall(e)))
             paste(" in", deparse(cc)[1L])
         else ""
         msg <- gettextf("package or namespace load failed for %s%s:\n %s",
             sQuote(package), P, conditionMessage(e))
         if (logical.return)
             message(past
  Execution halted

0 errors ✓ | 1 warning x | 1 note x
Error: R CMD check found WARNINGs
Execution halted

Exited with status 1.